### PR TITLE
feat(env variables): Add support for printing env templates and modified envcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ type Server struct {
 }
 ```
 
-Lastly, to remove all options without explicitly defining the keys and names,
+To remove all options without explicitly defining the keys and names,
 we can use the `-clear-options` flag. The following example will remove all
 options for the given struct:
 
@@ -399,6 +399,16 @@ type Server struct {
 		Password string `json:"password" xml:"password"`
 	} `json:"credentials" xml:"credentials"`
 }
+```
+
+**Environment Variables**
+
+In order to print an `.env` file template, use the `-print-envs` flag to default
+to `./.env` or add `-envs-filename /path/to/file` and it will create a new file
+with the path and name specified.
+
+```bash
+$ gomodifytags -file test-fixtures/all_structs.input -all -add-tags conf -template 'env:$field,noprint' -transform envcase -envs-filename 'path/to/.env' -print-envs
 ```
 
 ## Line based modification

--- a/test-fixtures/line_envcase_add.golden
+++ b/test-fixtures/line_envcase_add.golden
@@ -1,7 +1,7 @@
 package foo
 
 type foo struct {
-	bar       string `conf:"env:BAR"`
-	MyExample bool   `conf:"env:MY_EXAMPLE"`
+	bar       string `conf:"env:FOO_BAR"`
+	MyExample bool   `conf:"env:FOO_MY_EXAMPLE"`
 	MyAnother []string
 }


### PR DESCRIPTION
- add `-print-envs` flag which defaults to false in order to print an env template file
- add `-envs-filename` flag to change the default `./.env` file location
- modified envcase to add the struct name at the beginning of the env like: `STRUCT_ENV_VARIABLE`
- modified test cases
- modified README.md